### PR TITLE
Replace CSV storage with SQLite3 and add optional PostgreSQL support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,9 @@ pandas==2.3.2
 peewee==3.18.2
 platformdirs==4.4.0
 protobuf==6.32.0
+psycopg==3.2.9
+psycopg-binary==3.2.9
+psycopg-pool==3.2.6
 pycparser==2.22
 python-dateutil==2.9.0.post0
 pytz==2025.2


### PR DESCRIPTION
## Description

This PR removes the existing CSV-based storage method and introduces a SQLite3 backend by default. When all five environment variables (`PG_HOST`, `PG_PORT`, `PG_USER`, `PG_PASSWORD`, `PG_DB`) are defined, the script will automatically switch to PostgreSQL. The core workflow of data extraction, table initialization, and logging remains consistent across both backends.

## Motivation

Storing data in CSV files posed limitations around concurrency and schema evolution. Switching to SQLite3 by default offers improved performance, built-in locking, and easy local setup. Optional PostgreSQL support provides a seamless path to scale into managed or remote databases without disrupting the existing workflow.